### PR TITLE
fix bug about clear_buffer

### DIFF
--- a/src/io.c
+++ b/src/io.c
@@ -10,11 +10,11 @@ struct IO {
     const char *prompt;
 };
 
-static void clear_buffer(char *buffer)
+static void clear_buffer(char **buffer)
 {
-    if (buffer != NULL) {
-        free(buffer);
-        buffer = NULL;
+    if (*buffer != NULL) {
+        free(*buffer);
+        *buffer = NULL;
     }
 }
 
@@ -34,7 +34,7 @@ IO *IO_create(const char *prompt)
 void IO_destroy(IO *io)
 {
     if (io != NULL) {
-        clear_buffer(io->buffer);
+        clear_buffer(&io->buffer);
         free(io);
         io = NULL;
     }
@@ -53,7 +53,7 @@ const char *IO_read(IO *io, const char *prompt)
         printf("%s", io->prompt);
     }
 
-    clear_buffer(io->buffer);
+    clear_buffer(&io->buffer);
 
     size_t size;
     size = 0;


### PR DESCRIPTION
as you see, function clear_buffer in io.c just free(io->buffer), but it dose not change io->buffer's value to null.

it will case error like following:
regextodfa> dfa
enter regex below:
abc
regextodfa(399,0x7fff74ed3300) malloc: **\* error for object 0x100300040: pointer being realloc'd was not allocated
**\* set a breakpoint in malloc_error_break to debug

Program received signal SIGABRT, Aborted.
0x00007fff8f423286 in __pthread_kill ()
   from /usr/lib/system/libsystem_kernel.dylib
(gdb) bt
#0  0x00007fff8f423286 in __pthread_kill ()

   from /usr/lib/system/libsystem_kernel.dylib
#1  0x00007fff8ff4942f in pthread_kill ()

   from /usr/lib/system/libsystem_pthread.dylib
#2  0x00007fff8430eb53 in abort () from /usr/lib/system/libsystem_c.dylib
#3  0x00007fff91ad73cd in realloc ()

   from /usr/lib/system/libsystem_malloc.dylib
#4  0x00007fff842f05d7 in getdelim () from /usr/lib/system/libsystem_c.dylib
#5  0x0000000100001957 in IO_read (io=0x7fff74ed3300, prompt=<optimized out>)

```
at src/io.c:60
```
#6  0x00000001000013ab in command_dfa (client=0x100300040) at src/client.c:71
#7  run_command (client=<optimized out>, command=<optimized out>)

```
at src/client.c:179
```
#8  Client_run (client=0x100300040) at src/client.c:245
#9  0x0000000100002b76 in main (argc=<optimized out>, argv=0x6)

```
at src/regextodfa.c:12
```
